### PR TITLE
Remove hardcoded query operator

### DIFF
--- a/projects/amsui/src/lib/solr-service/solr.service.ts
+++ b/projects/amsui/src/lib/solr-service/solr.service.ts
@@ -33,6 +33,7 @@ export abstract class SolrService implements OnDestroy {
   protected searchResultsSubscription!: Subscription;
   protected solrSearchURL = '';
   protected solrSuggestURL = '';
+  protected operator: string = 'AND';
   protected numOfFound = -1;
   protected requestDebounceTime = 500;
   protected numberOfResults = 20;
@@ -184,7 +185,7 @@ export abstract class SolrService implements OnDestroy {
 
     const params = {
       q: keyword,
-      'q.op': 'AND',
+      'q.op': this.operator,
       'json.facet': JSON.stringify(facetConfigObject),
       rows: this.numberOfResults,
       start: this.offset,

--- a/projects/amsui/src/lib/solr-service/solr.service.ts
+++ b/projects/amsui/src/lib/solr-service/solr.service.ts
@@ -33,7 +33,7 @@ export abstract class SolrService implements OnDestroy {
   protected searchResultsSubscription!: Subscription;
   protected solrSearchURL = '';
   protected solrSuggestURL = '';
-  protected operator: string = 'AND';
+  protected operator = 'AND';
   protected numOfFound = -1;
   protected requestDebounceTime = 500;
   protected numberOfResults = 20;


### PR DESCRIPTION
To enable service implementations to change the query operator, removed hardcoded q.op from params and use a protected property which can be override by the implementations.